### PR TITLE
feat: allow custom host per api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ The UI no longer uses hard-coded PRs or code. It loads from the server:
 - `POST /api/review/:id` → issues + summary
 
 Patches update server-side file content; re-opening file reflects changes.
+
+## API host configuration
+Each API group can point to a different host for progressive integration. Set any of the following environment variables when starting the dev server or building:
+
+- `REACT_APP_API_HOST_PRS`
+- `REACT_APP_API_HOST_REVIEW`
+- `REACT_APP_API_HOST_PATCH`
+- `REACT_APP_API_HOST_CHAT`
+
+If a variable is not provided, requests fall back to the current origin.

--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,0 +1,13 @@
+export const API_BASE = {
+  prs: process.env.REACT_APP_API_HOST_PRS || '',
+  review: process.env.REACT_APP_API_HOST_REVIEW || '',
+  patch: process.env.REACT_APP_API_HOST_PATCH || '',
+  chat: process.env.REACT_APP_API_HOST_CHAT || ''
+};
+
+export function apiUrl(key, path) {
+  const base = API_BASE[key] || '';
+  return `${base}${path}`;
+}
+
+export default API_BASE;


### PR DESCRIPTION
## Summary
- add `apiUrl` helper and `API_BASE` config for per-endpoint hosts
- wire all requests in `PRReviewAgent` through configurable hosts
- document environment variables for api hosts

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689d3d1279d0832ba7684b9909b07d89