### PR TITLE
Expand layout to full width

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,12 +7,12 @@ export default function App() {
   return (
     <div className="min-h-screen">
       <div className="sticky top-0 z-30 border-b border-white/5 bg-black/30 backdrop-blur">
-        <div className="mx-auto max-w-[1300px] px-4 py-3 flex items-center gap-2">
+        <div className="px-4 py-3 flex items-center gap-2 w-full">
           <GitPullRequest className="h-5 w-5 text-sky-400" />
           <div className="text-sm text-slate-400">PR Review Agent • LangGraph (Demo)</div>
         </div>
       </div>
-      <div className="mx-auto max-w-[1300px] p-4">
+      <div className="p-4 w-full">
         <PRReviewAgent />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove centered max-width wrappers so the header and main grid span the full width
- ensure PRReviewAgent layout starts at the left edge with `w-full`

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a59899d2a0832b96f653272d611a16