### PR TITLE
Add markdown sanitization to PRReviewAgent

### DIFF
--- a/src/components/PRReviewAgent.jsx
+++ b/src/components/PRReviewAgent.jsx
@@ -3,6 +3,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import axios from 'axios';
 import { apiUrl } from '../apiConfig';
 import ReactMarkdown from 'react-markdown';
+import { stripHtml, allowedMarkdownElements } from '../markdown';
 import {
   AlertTriangle, Bot, Check, ChevronLeft, ChevronRight, ChevronsUpDown,
   MessageSquare, RefreshCw, Search, Wand2, XCircle, Folder, File
@@ -849,7 +850,12 @@ export default function PRReviewAgent(){
             </div>
           ) : (
             <div className="text-sm font-normal text-slate-300 leading-relaxed break-words prose prose-invert prose-sm max-w-none">
-              <ReactMarkdown>{summary || 'Run AI review to see insights.'}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[stripHtml]}
+                allowedElements={allowedMarkdownElements}
+              >
+                {summary || 'Run AI review to see insights.'}
+              </ReactMarkdown>
             </div>
           )}
         </div>

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,0 +1,42 @@
+export const allowedMarkdownElements = [
+  'a',
+  'b',
+  'blockquote',
+  'code',
+  'em',
+  'i',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'strong',
+  'ul',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6'
+];
+
+export function stripHtml() {
+  return (tree) => {
+    function traverse(node, index, parent) {
+      if (!node || typeof node !== 'object') return;
+
+      if (node.type === 'html' && parent && typeof index === 'number') {
+        parent.children.splice(index, 1);
+        return;
+      }
+
+      if (Array.isArray(node.children)) {
+        for (let i = node.children.length - 1; i >= 0; i--) {
+          traverse(node.children[i], i, node);
+        }
+      }
+    }
+
+    traverse(tree, null, null);
+  };
+}
+

--- a/src/markdown.test.js
+++ b/src/markdown.test.js
@@ -1,0 +1,57 @@
+import { stripHtml } from './markdown';
+
+describe('stripHtml plugin', () => {
+  it('removes script tags', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Hello' },
+            { type: 'html', value: '<script>alert("xss")</script>' },
+            { type: 'text', value: 'World' },
+          ],
+        },
+      ],
+    };
+    stripHtml()(tree);
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Hello' },
+            { type: 'text', value: 'World' },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('removes img tags', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Look' },
+            { type: 'html', value: '<img src=x onerror=alert(1)/>' },
+          ],
+        },
+      ],
+    };
+    stripHtml()(tree);
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Look' }],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent raw HTML from rendering by stripping disallowed tags in PRReviewAgent
- Restrict markdown rendering to a safe tag list
- Test that script and img tags are removed from markdown

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d3f5aca8832b8b4f7855e791de46