### PR TITLE
Refactor PRReviewAgent into components

### DIFF
--- a/src/components/FileTree.jsx
+++ b/src/components/FileTree.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { ChevronRight, FileText } from 'lucide-react';
+
+// Build a nested object representing the file hierarchy
+export const buildFileTree = files => {
+  const tree = {};
+  files.forEach(file => {
+    const parts = file.split('/');
+    let current = tree;
+    parts.forEach((part, i) => {
+      if (!current[part]) {
+        current[part] = {
+          type: i === parts.length - 1 ? 'file' : 'folder',
+          path: file,
+          children: {},
+        };
+      }
+      current = current[part].children;
+    });
+  });
+  return tree;
+};
+
+// Recursively render a collapsible file tree
+export default function FileTree({ tree, onFileClick, activeFile }) {
+  const [openFolders, setOpenFolders] = useState({});
+
+  const toggleFolder = path => {
+    setOpenFolders(prev => ({ ...prev, [path]: !prev[path] }));
+  };
+
+  const renderTree = (node, path = '', level = 0) => {
+    return Object.entries(node).map(([name, item]) => {
+      const currentPath = path ? `${path}/${name}` : name;
+      if (item.type === 'folder') {
+        return (
+          <div key={currentPath} className="text-sm">
+            <button
+              onClick={() => toggleFolder(currentPath)}
+              className="w-full flex items-center gap-1.5 rounded-md px-2 py-1 text-slate-400 hover:bg-white/5"
+            >
+              <ChevronRight
+                className={`h-4 w-4 shrink-0 transition-transform ${openFolders[currentPath] ? 'rotate-90' : ''}`}
+                style={{ marginLeft: `${level * 12}px` }}
+              />
+              <span className="truncate">{name}</span>
+            </button>
+            {openFolders[currentPath] && (
+              <div>{renderTree(item.children, currentPath, level + 1)}</div>
+            )}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          key={currentPath}
+          onClick={() => onFileClick(item.path)}
+          className={`w-full text-left flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-xs truncate transition-colors ${
+            activeFile === item.path ? 'bg-sky-500/20 text-sky-200' : 'text-slate-400 hover:bg-white/5'
+          }`}
+          title={item.path}
+          style={{ paddingLeft: `${level * 12 + 16}px` }}
+        >
+          <FileText className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{name}</span>
+        </button>
+      );
+    });
+  };
+
+  return <div>{renderTree(tree)}</div>;
+}
+

--- a/src/components/PRCard.jsx
+++ b/src/components/PRCard.jsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import {
+  GitBranch,
+  GitCommit,
+  FileText,
+  Clock,
+  Hash,
+  Bot as BotIcon,
+  User,
+  ChevronsUpDown as ToggleIcon,
+} from 'lucide-react';
+
+// Display a pull request in the list on the left.
+export default function PRCard({ pr, selected, onClick }) {
+  const [expanded, setExpanded] = useState(false);
+  const fileCount = Array.isArray(pr.files) ? pr.files.length : 0;
+  const firstFiles = (pr.files || []).slice(0, 3);
+  const overflow = Math.max(0, fileCount - firstFiles.length);
+  const avatar = pr.author ? `https://github.com/${pr.author}.png?size=40` : null;
+
+  return (
+    <div
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      aria-selected={selected}
+      className={`w-full text-left rounded-lg border px-2.5 py-1.5 transition ${
+        selected
+          ? 'border-sky-500/50 bg-sky-500/10 ring-1 ring-sky-400/30'
+          : 'border-white/10 bg-black/30 hover:bg-white/5'
+      }`}
+    >
+      {/* Title row */}
+      <div className="flex items-start gap-1.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <div className="truncate font-medium text-slate-200">
+              {pr.title || '(no title)'}
+            </div>
+            {pr.aiReviewed && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-violet-600/70 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white">
+                <BotIcon className="h-[12px] w-[12px]" /> AI
+              </span>
+            )}
+            <span className="ml-auto inline-flex items-center gap-1 text-xs text-slate-400">
+              <Clock className="h-3.5 w-3.5" />
+              {pr.updatedAgo}
+            </span>
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                setExpanded(v => !v);
+              }}
+              className="ml-1 text-slate-400 hover:text-slate-200"
+              aria-label={expanded ? 'Collapse metadata' : 'Expand metadata'}
+            >
+              <ToggleIcon
+                className={`h-3.5 w-3.5 transition-transform ${expanded ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </div>
+
+          {expanded && (
+            <>
+              {/* Meta row */}
+              <div className="mt-1 flex items-center gap-3 text-xs text-slate-400">
+                <span title={pr.repo} className="truncate">
+                  {pr.repo}
+                </span>
+                <span className="text-slate-600">•</span>
+                <span className="inline-flex items-center gap-1 truncate" title={pr.branch}>
+                  <GitBranch className="h-3.5 w-3.5" />
+                  {pr.branch}
+                </span>
+                <span className="text-slate-600">•</span>
+                <span className="inline-flex items-center gap-1">
+                  <Hash className="h-3.5 w-3.5" />#{pr.id}
+                </span>
+                {pr.headSha && (
+                  <>
+                    <span className="text-slate-600">•</span>
+                    <span className="inline-flex items-center gap-1" title={pr.headSha}>
+                      <Hash className="h-3.5 w-3.5" />
+                      {String(pr.headSha).slice(0, 7)}
+                    </span>
+                  </>
+                )}
+              </div>
+
+              {/* Stats row */}
+              <div className="mt-1.5 flex items-center gap-2.5 text-xs text-slate-400">
+                <span className="inline-flex items-center gap-1">
+                  <GitCommit className="h-3.5 w-3.5" />
+                  {pr.commit ?? 0} commit{(pr.commit ?? 0) === 1 ? '' : 's'}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <FileText className="h-3.5 w-3.5" />
+                  {fileCount} file{fileCount === 1 ? '' : 's'}
+                </span>
+                <span className="ml-auto inline-flex items-center gap-1 text-slate-500">
+                  by <span className="text-slate-300">{pr.author || 'unknown'}</span>
+                </span>
+              </div>
+
+              {/* File chips preview */}
+              {fileCount > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {firstFiles.map(name => (
+                    <span
+                      key={name}
+                      title={name}
+                      className="max-w-[220px] truncate rounded-md border border-white/10 bg-black/20 px-1 py-0.5 font-mono text-[10px] text-slate-300"
+                    >
+                      {name}
+                    </span>
+                  ))}
+                  {overflow > 0 && (
+                    <span className="rounded-md border border-white/10 bg-black/20 px-1 py-0.5 text-[10px] text-slate-400">
+                      +{overflow} more
+                    </span>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Avatar */}
+        <div className="shrink-0">
+          {avatar ? (
+            <img
+              alt={pr.author}
+              src={avatar}
+              className="h-6 w-6 rounded-full border border-white/10 object-cover"
+            />
+          ) : (
+            <div className="h-6 w-6 rounded-full border border-white/10 bg-white/10 flex items-center justify-center">
+              <User className="h-4 w-4 text-slate-400" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Skeleton placeholder while pull requests load
+export function PRCardSkeleton() {
+  return (
+    <div className="w-full rounded-lg border border-white/10 bg-black/30 p-2.5">
+      <div className="animate-pulse">
+        <div className="h-4 bg-slate-700 rounded w-3/4"></div>
+        <div className="mt-1.5 h-3 bg-slate-700 rounded w-1/2"></div>
+        <div className="mt-3 flex items-center gap-2.5 text-xs text-slate-400">
+          <div className="h-4 w-16 bg-slate-700 rounded"></div>
+          <div className="h-4 w-16 bg-slate-700 rounded"></div>
+        </div>
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          <div className="h-5 w-24 bg-slate-700 rounded-md"></div>
+          <div className="h-5 w-20 bg-slate-700 rounded-md"></div>
+          <div className="h-5 w-28 bg-slate-700 rounded-md"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/PRReviewAgent.jsx
+++ b/src/components/PRReviewAgent.jsx
@@ -5,13 +5,24 @@ import { apiUrl } from '../apiConfig';
 import ReactMarkdown from 'react-markdown';
 import { stripHtml, allowedMarkdownElements } from '../markdown';
 import {
-  AlertTriangle, Bot, Check, ChevronLeft, ChevronRight, ChevronsUpDown,
-  MessageSquare, RefreshCw, Search, Wand2, XCircle, Folder, File
+  AlertTriangle,
+  Bot,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+  MessageSquare,
+  RefreshCw,
+  Search,
+  Wand2,
+  XCircle
 } from 'lucide-react';
 
 import Button from './ui/Button';
 import Badge from './ui/Badge';
 import Switch from './ui/Switch';
+import PRCard, { PRCardSkeleton } from './PRCard';
+import FileTree, { buildFileTree } from './FileTree';
 
 const severityTone = {
   critical: 'bg-red-500/15 text-red-300 border-red-500/30',
@@ -28,233 +39,6 @@ const severityOrder = {
   low: 4,
   minor: 5,
 };
-
-import {
-  GitBranch,
-  GitCommit,
-  FileText,
-  Clock,
-  Hash,
-  Bot as BotIcon,
-  User,
-  ChevronsUpDown as ToggleIcon,
-} from 'lucide-react';
-
-function PRCard({ pr, selected, onClick }) {
-  const [expanded, setExpanded] = useState(false);
-  const fileCount = Array.isArray(pr.files) ? pr.files.length : 0;
-  const firstFiles = (pr.files || []).slice(0, 3);
-  const overflow = Math.max(0, fileCount - firstFiles.length);
-  const avatar = pr.author ? `https://github.com/${pr.author}.png?size=40` : null;
-
-  return (
-    <div
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
-      aria-selected={selected}
-      className={`w-full text-left rounded-lg border px-2.5 py-1.5 transition ${
-        selected
-          ? 'border-sky-500/50 bg-sky-500/10 ring-1 ring-sky-400/30'
-          : 'border-white/10 bg-black/30 hover:bg-white/5'
-      }`}
-    >
-      {/* Title row */}
-      <div className="flex items-start gap-1.5">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <div className="truncate font-medium text-slate-200">{pr.title || '(no title)'}</div>
-            {pr.aiReviewed && (
-              <span className="inline-flex items-center gap-1 rounded-md bg-violet-600/70 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white">
-                <BotIcon className="h-[12px] w-[12px]" /> AI
-              </span>
-            )}
-            <span className="ml-auto inline-flex items-center gap-1 text-xs text-slate-400">
-              <Clock className="h-3.5 w-3.5" />
-              {pr.updatedAgo}
-            </span>
-            <button
-              onClick={e => {
-                e.stopPropagation();
-                setExpanded(v => !v);
-              }}
-              className="ml-1 text-slate-400 hover:text-slate-200"
-              aria-label={expanded ? 'Collapse metadata' : 'Expand metadata'}
-            >
-              <ToggleIcon className={`h-3.5 w-3.5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
-            </button>
-          </div>
-
-          {expanded && (
-            <>
-              {/* Meta row */}
-              <div className="mt-1 flex items-center gap-3 text-xs text-slate-400">
-                <span title={pr.repo} className="truncate">
-                  {pr.repo}
-                </span>
-                <span className="text-slate-600">•</span>
-                <span className="inline-flex items-center gap-1 truncate" title={pr.branch}>
-                  <GitBranch className="h-3.5 w-3.5" />
-                  {pr.branch}
-                </span>
-                <span className="text-slate-600">•</span>
-                <span className="inline-flex items-center gap-1">
-                  <Hash className="h-3.5 w-3.5" />#{pr.id}
-                </span>
-                {pr.headSha && (
-                  <>
-                    <span className="text-slate-600">•</span>
-                    <span className="inline-flex items-center gap-1" title={pr.headSha}>
-                      <Hash className="h-3.5 w-3.5" />
-                      {String(pr.headSha).slice(0, 7)}
-                    </span>
-                  </>
-                )}
-              </div>
-
-              {/* Stats row */}
-              <div className="mt-1.5 flex items-center gap-2.5 text-xs text-slate-400">
-                <span className="inline-flex items-center gap-1">
-                  <GitCommit className="h-3.5 w-3.5" />
-                  {pr.commit ?? 0} commit{(pr.commit ?? 0) === 1 ? '' : 's'}
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <FileText className="h-3.5 w-3.5" />
-                  {fileCount} file{fileCount === 1 ? '' : 's'}
-                </span>
-                <span className="ml-auto inline-flex items-center gap-1 text-slate-500">
-                  by <span className="text-slate-300">{pr.author || 'unknown'}</span>
-                </span>
-              </div>
-
-              {/* File chips preview */}
-              {fileCount > 0 && (
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {firstFiles.map(name => (
-                    <span
-                      key={name}
-                      title={name}
-                      className="max-w-[220px] truncate rounded-md border border-white/10 bg-black/20 px-1 py-0.5 font-mono text-[10px] text-slate-300"
-                    >
-                      {name}
-                    </span>
-                  ))}
-                  {overflow > 0 && (
-                    <span className="rounded-md border border-white/10 bg-black/20 px-1 py-0.5 text-[10px] text-slate-400">
-                      +{overflow} more
-                    </span>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-        </div>
-
-        {/* Avatar */}
-        <div className="shrink-0">
-          {avatar ? (
-            <img
-              alt={pr.author}
-              src={avatar}
-              className="h-6 w-6 rounded-full border border-white/10 object-cover"
-            />
-          ) : (
-            <div className="h-6 w-6 rounded-full border border-white/10 bg-white/10 flex items-center justify-center">
-              <User className="h-4 w-4 text-slate-400" />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function PRCardSkeleton() {
-  return (
-    <div className="w-full rounded-lg border border-white/10 bg-black/30 p-2.5">
-      <div className="animate-pulse">
-        <div className="h-4 bg-slate-700 rounded w-3/4"></div>
-        <div className="mt-1.5 h-3 bg-slate-700 rounded w-1/2"></div>
-        <div className="mt-3 flex items-center gap-2.5 text-xs text-slate-400">
-          <div className="h-4 w-16 bg-slate-700 rounded"></div>
-          <div className="h-4 w-16 bg-slate-700 rounded"></div>
-        </div>
-        <div className="mt-1.5 flex flex-wrap gap-1">
-          <div className="h-5 w-24 bg-slate-700 rounded-md"></div>
-          <div className="h-5 w-20 bg-slate-700 rounded-md"></div>
-          <div className="h-5 w-28 bg-slate-700 rounded-md"></div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const buildFileTree = (files) => {
-  const tree = {};
-
-  files.forEach(file => {
-    const parts = file.split('/');
-    let currentLevel = tree;
-
-    parts.forEach((part, i) => {
-      if (!currentLevel[part]) {
-        currentLevel[part] = { type: i === parts.length - 1 ? 'file' : 'folder', path: file, children: {} };
-      }
-      currentLevel = currentLevel[part].children;
-    });
-  });
-
-  return tree;
-};
-
-const FileTree = ({ tree, onFileClick, activeFile }) => {
-  const [openFolders, setOpenFolders] = useState({});
-
-  const toggleFolder = (path) => {
-    setOpenFolders(prev => ({ ...prev, [path]: !prev[path] }));
-  };
-
-  const renderTree = (node, path = '', level = 0) => {
-    return Object.entries(node).map(([name, item]) => {
-      const currentPath = path ? `${path}/${name}` : name;
-      if (item.type === 'folder') {
-        return (
-          <div key={currentPath} className="text-sm">
-            <button onClick={() => toggleFolder(currentPath)} className="w-full flex items-center gap-1.5 rounded-md px-2 py-1 text-slate-400 hover:bg-white/5">
-              <ChevronRight className={`h-4 w-4 shrink-0 transition-transform ${openFolders[currentPath] ? 'rotate-90' : ''}`} style={{ marginLeft: `${level * 12}px` }} />
-              <span className="truncate">{name}</span>
-            </button>
-            {openFolders[currentPath] && (
-              <div className="">
-                {renderTree(item.children, currentPath, level + 1)}
-              </div>
-            )}
-          </div>
-        );
-      }
-
-      return (
-        <button
-          key={currentPath}
-          onClick={() => onFileClick(item.path)}
-          className={`w-full text-left flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-xs truncate transition-colors ${
-            activeFile === item.path
-              ? 'bg-sky-500/20 text-sky-200'
-              : 'text-slate-400 hover:bg-white/5'
-          }`}
-          title={item.path}
-		  style={{ paddingLeft: `${(level * 12) + 16}px` }}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">{name}</span>
-        </button>
-      );
-    });
-  };
-
-  return <div>{renderTree(tree)}</div>;
-};
-
 
 export default function PRReviewAgent(){
 


### PR DESCRIPTION
## Summary
- extract PRCard component and its skeleton into `PRCard.jsx`
- create reusable `FileTree` component with helper `buildFileTree`
- update `PRReviewAgent` to use the new components and clean up imports

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7bacc2c832ba3fb8ed3cd0eed36