### PR TITLE
Fix Hash icon reference and add dark mode toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>PR Review Agent</title>
   </head>
-  <body class="bg-[#0c0c0e]">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,35 @@
 
 import React from 'react';
-import { GitPullRequest } from 'lucide-react';
+import { GitPullRequest, Moon, Sun } from 'lucide-react';
 import PRReviewAgent from './components/PRReviewAgent';
 
 export default function App() {
+  const [darkMode, setDarkMode] = React.useState(true);
+
+  React.useEffect(() => {
+    const root = window.document.documentElement;
+    if (darkMode) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [darkMode]);
+
   return (
     <div className="min-h-screen">
-      <div className="sticky top-0 z-30 border-b border-white/5 bg-black/30 backdrop-blur">
-        <div className="px-4 py-3 flex items-center gap-2 w-full">
-          <GitPullRequest className="h-5 w-5 text-sky-400" />
-          <div className="text-sm text-slate-400">PR Review Agent • LangGraph (Demo)</div>
+      <div className="sticky top-0 z-30 border-b border-black/5 bg-white/70 backdrop-blur dark:border-white/5 dark:bg-black/30">
+        <div className="px-4 py-3 flex items-center gap-2 w-full justify-between">
+          <div className="flex items-center gap-2">
+            <GitPullRequest className="h-5 w-5 text-sky-400" />
+            <div className="text-sm text-slate-700 dark:text-slate-400">PR Review Agent • LangGraph (Demo)</div>
+          </div>
+          <button
+            onClick={() => setDarkMode(!darkMode)}
+            className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/5"
+            aria-label="Toggle dark mode"
+          >
+            {darkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </button>
         </div>
       </div>
       <div className="p-4 w-full">

--- a/src/components/PRReviewAgent.jsx
+++ b/src/components/PRReviewAgent.jsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronsUpDown,
+  Hash,
   MessageSquare,
   RefreshCw,
   Search,
@@ -462,8 +463,8 @@ export default function PRReviewAgent(){
   return (
     <div className="grid gap-4 sm:grid-cols-10">
       {/* Left */}
-      <div className="sm:col-span-2 h-[78vh] border border-white/10 rounded-2xl bg-white/5 p-3 flex flex-col">
-        <div className="flex items-center justify-between text-sm font-medium text-slate-300 mb-2">
+      <div className="sm:col-span-2 h-[78vh] border rounded-2xl p-3 flex flex-col border-black/10 bg-black/5 dark:border-white/10 dark:bg-white/5">
+        <div className="flex items-center justify-between text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
           <span>Pull Requests</span>
           <Badge className="border-sky-500/30 text-sky-300 font-medium">
             {loadingPRs ? <RefreshCw className="h-3 w-3 animate-spin" /> : filteredPRs.length}
@@ -479,13 +480,13 @@ export default function PRReviewAgent(){
           <div className="relative mb-3" ref={repoDropdownRef}>
             <button
               onClick={() => setRepoDropdownOpen(!repoDropdownOpen)}
-              className="w-full flex items-center justify-between bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm font-normal text-slate-200"
+              className="w-full flex items-center justify-between bg-white border border-black/10 rounded-lg px-3 py-2 text-sm font-normal text-slate-800 dark:bg-black/40 dark:border-white/10 dark:text-slate-200"
             >
               <span className="truncate">{selectedRepo || 'Select a repository'}</span>
-              <ChevronsUpDown className="h-4 w-4 text-slate-400 shrink-0" />
+              <ChevronsUpDown className="h-4 w-4 text-slate-500 dark:text-slate-400 shrink-0" />
             </button>
             {repoDropdownOpen && (
-              <div className="absolute z-10 mt-1 w-full bg-[#1c1c1c] border border-white/20 rounded-lg shadow-lg">
+              <div className="absolute z-10 mt-1 w-full bg-white border border-black/20 rounded-lg shadow-lg dark:bg-[#1c1c1c] dark:border-white/20">
                 <div className="p-2">
                   <div className="relative">
                     <Search className="pointer-events-none absolute left-2 top-2.5 h-4 w-4 text-slate-400"/>
@@ -494,7 +495,7 @@ export default function PRReviewAgent(){
                       placeholder="Search repositories..."
                       value={repoSearch}
                       onChange={(e) => setRepoSearch(e.target.value)}
-                      className="w-full bg-black/40 pl-8 pr-2 py-2 rounded-lg text-sm font-normal placeholder:text-slate-500 border border-white/10"
+                      className="w-full bg-white pl-8 pr-2 py-2 rounded-lg text-sm font-normal text-slate-800 placeholder:text-slate-500 border border-black/10 dark:bg-black/40 dark:text-slate-200 dark:border-white/10"
                     />
                   </div>
                 </div>
@@ -508,7 +509,7 @@ export default function PRReviewAgent(){
                           setRepoDropdownOpen(false);
                           setRepoSearch('');
                         }}
-                        className="w-full text-left flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-200 hover:bg-white/10"
+                        className="w-full text-left flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-800 hover:bg-black/5 dark:text-slate-200 dark:hover:bg-white/10"
                       >
                         <span className="flex-1 truncate">{repo}</span>
                         {repo === selectedRepo && <Check className="h-4 w-4 text-sky-400" />}
@@ -530,16 +531,16 @@ export default function PRReviewAgent(){
         <div className="flex items-center gap-2 mb-3">
           <div className="relative w-full">
             <Search className="pointer-events-none absolute left-2 top-2.5 h-4 w-4 text-slate-400"/>
-            <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search PRs…" className="w-full bg-black/40 pl-8 pr-2 py-2 rounded-lg text-sm font-normal placeholder:text-slate-500 border border-white/10"/>
+            <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search PRs…" className="w-full bg-white pl-8 pr-2 py-2 rounded-lg text-sm font-normal text-slate-800 placeholder:text-slate-500 border border-black/10 dark:bg-black/40 dark:text-slate-200 dark:border-white/10"/>
           </div>
         </div>
-        <div className="flex items-center justify-between text-xs font-medium text-slate-400 mb-2">
+        <div className="flex items-center justify-between text-xs font-medium text-slate-600 dark:text-slate-400 mb-2">
           <label className="flex items-center gap-2"><Switch checked={filterMine} onChange={setFilterMine}/> Mine</label>
           <label className="flex items-center gap-2"><Switch checked={filterAI} onChange={setFilterAI}/> Has AI</label>
         </div>
         <div className="scroll-y grow pr-1 space-y-2">
           {prError && (
-            <div className="text-xs text-red-400 flex items-center p-2 bg-red-500/10 rounded">
+            <div className="text-xs text-red-600 dark:text-red-400 flex items-center p-2 bg-red-500/10 rounded">
               <XCircle className="h-3 w-3 mr-1" /> {prError}
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -3,11 +3,13 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: dark; }
+:root { color-scheme: light; }
+.dark { color-scheme: dark; }
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; }
-body { @apply bg-[#0c0c0e] text-slate-200; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
+body { @apply bg-white text-slate-900; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
+.dark body { @apply bg-[#0c0c0e] text-slate-200; }
 
 /* Simple scroll area */
 .scroll-y { overflow-y: auto; scrollbar-width: thin; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{js,jsx}","./public/index.html"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- import missing `Hash` icon to resolve runtime error in `PRReviewAgent`
- add dark/light mode toggle with theme-aware styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65f1f1c44832bba47cc0ccfe87904