### PR TITLE
Add theme toggle for dark/light mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,10 @@
 
 import React from 'react';
-import { GitPullRequest, Moon, Sun } from 'lucide-react';
+import { GitPullRequest } from 'lucide-react';
 import PRReviewAgent from './components/PRReviewAgent';
+import ThemeToggle from './components/ThemeToggle';
 
 export default function App() {
-  const [darkMode, setDarkMode] = React.useState(true);
-
-  React.useEffect(() => {
-    const root = window.document.documentElement;
-    if (darkMode) {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
-  }, [darkMode]);
-
   return (
     <div className="min-h-screen">
       <div className="sticky top-0 z-30 border-b border-black/5 bg-white/70 backdrop-blur dark:border-white/5 dark:bg-black/30">
@@ -23,13 +13,7 @@ export default function App() {
             <GitPullRequest className="h-5 w-5 text-sky-400" />
             <div className="text-sm text-slate-700 dark:text-slate-400">PR Review Agent • LangGraph (Demo)</div>
           </div>
-          <button
-            onClick={() => setDarkMode(!darkMode)}
-            className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/5"
-            aria-label="Toggle dark mode"
-          >
-            {darkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-          </button>
+          <ThemeToggle />
         </div>
       </div>
       <div className="p-4 w-full">

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+
+export default function ThemeToggle() {
+  const [darkMode, setDarkMode] = React.useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+
+  React.useEffect(() => {
+    const root = window.document.documentElement;
+    if (darkMode) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [darkMode]);
+
+  return (
+    <button
+      onClick={() => setDarkMode(!darkMode)}
+      className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/5"
+      aria-label="Toggle dark mode"
+    >
+      {darkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ThemeToggle` component that switches theme between dark and light using `lucide-react` icons
- integrate the new toggle into the header for easy access

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a9e9c2c2c4832bab1ade771626a924